### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/fp-plugins/gdprvideoembed/res/gdpr-video-embed.js
+++ b/fp-plugins/gdprvideoembed/res/gdpr-video-embed.js
@@ -57,9 +57,9 @@
 
 			// Replace the placeholders with the extracted video ID or URL
 			if (video_platform === 'facebook') {
-				responsive_bbcode_video.innerHTML = window.gdprConfig.text[video_platform].replace(/\%video_url\%/g, video_url);
+				responsive_bbcode_video.textContent = window.gdprConfig.text[video_platform].replace(/\%video_url\%/g, video_url);
 			} else {
-				responsive_bbcode_video.innerHTML = window.gdprConfig.text[video_platform].replace(/\%id\%/g, video_id);
+				responsive_bbcode_video.textContent = window.gdprConfig.text[video_platform].replace(/\%id\%/g, video_id);
 			}
 
 			video_frame.parentNode.replaceChild(responsive_bbcode_video, video_frame);


### PR DESCRIPTION
Potential fix for [https://github.com/Fraenkiman/flatpress/security/code-scanning/2](https://github.com/Fraenkiman/flatpress/security/code-scanning/2)

To fix the issue, we need to ensure that any untrusted data, such as `video_id`, is properly escaped before being inserted into the DOM. Instead of using `.innerHTML`, which interprets the string as HTML, we can use `.textContent` to safely insert the text as plain content. Alternatively, if HTML is required, we can use a library like `DOMPurify` to sanitize the content.

In this case, the best approach is to replace `.innerHTML` with `.textContent` for safety, as it avoids interpreting the string as HTML. This change ensures that any special characters in `video_id` are treated as plain text, preventing XSS.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
