### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/fp-plugins/gdprvideoembed/res/gdpr-video-embed.js
+++ b/fp-plugins/gdprvideoembed/res/gdpr-video-embed.js
@@ -56,11 +56,13 @@
 			}
 
 			// Replace the placeholders with the extracted video ID or URL
+			let content;
 			if (video_platform === 'facebook') {
-				responsive_bbcode_video.innerHTML = window.gdprConfig.text[video_platform].replace(/\%video_url\%/g, video_url);
+				content = window.gdprConfig.text[video_platform].replace(/\%video_url\%/g, video_url);
 			} else {
-				responsive_bbcode_video.innerHTML = window.gdprConfig.text[video_platform].replace(/\%id\%/g, video_id);
+				content = window.gdprConfig.text[video_platform].replace(/\%id\%/g, video_id);
 			}
+			responsive_bbcode_video.textContent = content;
 
 			video_frame.parentNode.replaceChild(responsive_bbcode_video, video_frame);
 			document.querySelectorAll('.video-responsive_bbcode_video button')[i].addEventListener('click', function () {


### PR DESCRIPTION
Potential fix for [https://github.com/Fraenkiman/flatpress/security/code-scanning/1](https://github.com/Fraenkiman/flatpress/security/code-scanning/1)

To fix the issue, we need to ensure that the `video_url` is properly escaped or sanitized before being inserted into the DOM. Instead of using `innerHTML`, which interprets the string as HTML, we can use `textContent` to safely insert the text as plain text. This approach prevents the browser from interpreting the content as HTML, thereby mitigating the XSS risk.

The changes will involve:
1. Replacing the use of `innerHTML` with `textContent` for the `responsive_bbcode_video` element.
2. Modifying the logic to construct the content string outside of the DOM and then safely assign it to `textContent`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
